### PR TITLE
Clean up dependencies and README file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,32 @@
+# 0.0.1
+Initial version
+
+# 0.0.2
+Fix `base` path in `gutil.File` to preserve directory structure
+
+# 0.0.3
+Fix stylus regexp
+
+# 0.0.4
+Add empty setting object for unsupported file type
+
+# 0.0.5
+Fix extensions list
+
+# 0.0.6
+Add `multiple import` for sass and `file glob` for stylus
+
+# 0.0.7
+Drop support for apostroph
+
+# 0.0.8
+Add support for index styles
+
+# 0.1.1
+Add dependencies removal
+
+# 0.2.0
+Add file.stats for other plugins
+
+# 0.3.1
+Drop the inbuilt parser for the `es128/progeny` package

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 gulp-progeny [![Build Status](https://travis-ci.org/HerringtonDarkholme/gulp-progeny.svg?branch=master)](https://travis-ci.org/HerringtonDarkholme/gulp-progeny)
 ===============
-A dependency-resolving plugin for gulp.
+A dependency-resolving plugin for Gulp.
 It grabs all files related to one edition to building system.
 
 ##Introduction
@@ -18,7 +18,7 @@ It provides generic dependency detection to various file types.
 So it just use Regular Expression to extract dependency information. This simple solution is fast and dirty, but also working.
 
 ##Usage
-`gulp-progeny` out of box supports `jade`, `jedi`,`less`, `sass` and `stylus`.
+`gulp-progeny` out of box supports `jade`, `less`, `sass` and `stylus`.
 To exploit the power of `gulp-progeny`, use `gulp-cached` in tandem.
 
 ```javascript
@@ -41,71 +41,14 @@ gulp.task('watch', function(){
 `cached` will pass all files to `progeny` in the first run, which enables dependency tree building,
 just pass changed files later for incremental building.
 
-##advanced configuration
-Generally same as brunch's [progeny](https://github.com/es128/progeny).
-Just pass configuration to progeny constructor.
+## Advanced configuration
+As `gulp-progeny` includes `progeny` in its core, please see their [configuration docs](https://github.com/es128/progeny#configuration) for the options that can be used with this plugin.
 
-```javascript
-var progenyConfig = {
-    // The file extension for the source code you want parsed
-    // Will be derived from the source file path if not specified
-    extension: 'styl',
-
-    // Array of multiple file extensions to try when looking for dependencies
-    extensionsList: ['scss', 'sass'],
-
-    // Regexp to run on each line of source code to match dependency references
-    // Make sure you wrap the file name part in (parentheses)
-    regexp: /^\s*@import\s+['"]?([^'"]+)['"]?/,
-
-    // File prefix to try (in addition to the raw value matched in the regexp)
-    prefix: '_',
-
-    // Matched stuff to exclude: string, regex, or array of either/both
-    exclusion: /^compass/,
-
-    // which file to find when import directory as a whole
-    // don't include extension here
-    // e.g. @import 'blueprint' is expanded to @import 'blueprint/index.styl'
-    directoryEntry: 'index',
-
-    // In case a match starts with a slash, the absolute path to apply
-    rootPath: path.join('path', 'to', 'project'),
-
-    // all dependencies will be printed out in debug mode
-    debug: true
-};
-var progeny = require('gulp-progeny')
-
-gulp.src('*.styl').pipe(progeny(progenyConfig))
-```
-
-### limitation
-Gulp-progeny, by the virtue of its design, has following limitations.
+### Limitation
+`gulp-progeny`, by the virtue of its design, has following limitations.
 
 1. Filenames must be static in source code. Otherwise regexp fails to work.
 
 2. Sass/Scss filenames should not contain apostrophes. This limitation is due toSass's [multiple import feature](http://sass-lang.com/documentation/file.SASS_REFERENCE.html#import). Matching filenames with `'"` is far beyond the reach of regular expressions with only one match, which is the format used in this plug in.
 
 Limitations above are almost ineluctable for this simple plugin. To keep API and extension simple and generic, some features are doomed to be dropped. This plugin does not fill the chasm between a single one Regexp and full-bloom parsers.
-
-### changelog
-0.0.1 initial version
-
-0.0.2 fix `base` path in `gutil.File` to preserve directory structure
-
-0.0.3 fix stylus regexp
-
-0.0.4 add empty setting object for unsupported file type
-
-0.0.5 fix extensions list
-
-0.0.6 add `multiple import` for sass and `file glob` for stylus
-
-0.0.7 drop support for apostroph
-
-0.0.8 add support for index styles
-
-0.1.1 add dependencies removal
-
-0.2.0 add file.stats for other plugins

--- a/package.json
+++ b/package.json
@@ -13,17 +13,15 @@
     "compile"
   ],
   "dependencies": {
-    "colors": "^1.1.2",
-    "glob": "^4.0.5",
-    "gulp-util": "^2.2.20",
+    "gulp-util": "^3.0.7",
     "progeny": "^0.7.0",
-    "through2": "^0.5.1"
+    "through2": "^2.0.1"
   },
   "devDependencies": {
     "coffee-script": "^1.9.3",
     "gulp": "^3.8.6",
     "gulp-coffee": "^2.1.1",
-    "gulp-mocha": "^0.5.2",
+    "gulp-mocha": "^2.2.0",
     "mocha": "*"
   },
   "author": "Herrington Darkholme",


### PR DESCRIPTION
I had spare time so I checked the dependencies and realised I forgot to clean the unused deps up. Took the opportunity to clean up the README file, separate the changelog into a common file, and bump up other deps as well.